### PR TITLE
fix(next.config.ts): remove await from setupDevPlatform function call

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,7 +25,7 @@ const nextConfig: NextConfig = {
 };
 
 if (process.env.NODE_ENV === "development") {
-  await setupDevPlatform();
+  setupDevPlatform();
 }
 
 const withMDX = createMDX({});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "target": "es2017",
+    "target": "ES6",
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
This pull request includes a minor update to the `next.config.ts` file. The change removes the `await` keyword from the `setupDevPlatform` function call, ensuring it runs synchronously in the development environment.…opment mode

fix(tsconfig.json): change target from 'es2017' to 'ES6'